### PR TITLE
fix(server): use env-configured embeddings and fix process keepalive in server CLI

### DIFF
--- a/src/server/cli/server.ts
+++ b/src/server/cli/server.ts
@@ -1,8 +1,9 @@
-import type { Embeddings } from '@langchain/core/embeddings';
 import { createServerApp } from '../main.js';
 import { loadServerConfig } from '../config.js';
 import { autoConfig } from '../../powermem/config_loader.js';
 import { isEmbeddedStorage } from './embedded-storage.js';
+import { createEmbeddings } from '../../powermem/integrations/embeddings/factory.js';
+import type { Embeddings } from '@langchain/core/embeddings';
 
 const config = loadServerConfig();
 const memoryConfig = autoConfig();
@@ -15,27 +16,53 @@ if (!config.reload && config.workers !== 1 && isEmbeddedStorage(memoryConfig)) {
 }
 
 let embeddings: Embeddings | undefined;
-try {
-  const { OllamaEmbeddings } = await import('@langchain/ollama');
-  embeddings = new OllamaEmbeddings({ model: 'nomic-embed-text', baseUrl: 'http://localhost:11434' });
-} catch {
-  const { Embeddings: EmbBase } = await import('@langchain/core/embeddings');
-  class DemoEmbeddings extends EmbBase {
-    async embedQuery(text: string) { return Array.from({ length: 8 }, (_, i) => text.charCodeAt(i % text.length) / 256); }
-    async embedDocuments(docs: string[]) { return docs.map((doc) => this.embedQuery(doc) as never); }
+const embedderConf = memoryConfig.embedder;
+if (embedderConf?.provider && embedderConf.config) {
+  try {
+    embeddings = await createEmbeddings({
+      provider: embedderConf.provider,
+      ...(embedderConf.config as Record<string, unknown>),
+    } as Parameters<typeof createEmbeddings>[0]);
+    console.log(`[server] Using configured embeddings: ${embedderConf.provider}/${(embedderConf.config as Record<string, unknown>).model ?? 'default'}`);
+  } catch (err) {
+    console.error(`[server] Failed to create embeddings from config (${embedderConf.provider}):`, err);
   }
-  embeddings = new DemoEmbeddings({});
 }
 
-createServerApp({
+if (!embeddings) {
+  try {
+    const { OllamaEmbeddings } = await import('@langchain/ollama');
+    embeddings = new OllamaEmbeddings({ model: 'nomic-embed-text', baseUrl: 'http://localhost:11434' });
+    console.log('[server] Fallback: using Ollama embeddings');
+  } catch {
+    const { Embeddings: EmbBase } = await import('@langchain/core/embeddings');
+    class DemoEmbeddings extends EmbBase {
+      async embedQuery(text: string) { return Array.from({ length: 8 }, (_, i) => text.charCodeAt(i % text.length) / 256); }
+      async embedDocuments(docs: string[]) { return docs.map((doc) => this.embedQuery(doc) as never); }
+    }
+    embeddings = new DemoEmbeddings({});
+    console.log('[server] Fallback: using DemoEmbeddings (8-dim)');
+  }
+}
+
+const { app } = await createServerApp({
   dbPath: process.env.DB_PATH,
   embeddings,
   memoryConfig,
   config,
-}).then(({ app }) => {
-  app.listen(config.port, config.host, () => {
-    console.log(`PowerMem API server running at http://${config.host}:${config.port}/`);
-    console.log(`API at http://${config.host}:${config.port}/api/v1/`);
-    console.log(`Docs at http://${config.host}:${config.port}/docs`);
-  });
+});
+
+const server = app.listen(config.port, config.host, () => {
+  console.log(`PowerMem API server running at http://${config.host}:${config.port}/`);
+  console.log(`API at http://${config.host}:${config.port}/api/v1/`);
+  console.log(`Docs at http://${config.host}:${config.port}/docs`);
+});
+
+process.on('SIGTERM', () => {
+  console.log('[server] SIGTERM received, shutting down…');
+  server.close();
+});
+process.on('SIGINT', () => {
+  console.log('[server] SIGINT received, shutting down…');
+  server.close();
 });


### PR DESCRIPTION
## Description

Fixes two server CLI bugs: (1) embeddings always defaulting to Ollama instead of reading `.env` config, and (2) process exiting immediately after startup due to `.then()` + ESM top-level-await interaction.

## Related Issues

Closes #27

## Changes

- Prioritize `autoConfig().embedder` settings via `createEmbeddings()` factory before falling back to Ollama/DemoEmbeddings.
- Replace `.then()` pattern with `await` + explicit `const server = app.listen(...)` to keep the event loop alive.
- Add `SIGTERM`/`SIGINT` handlers for graceful shutdown.
- Log which embedding provider is being used at startup.

## Test Plan

- [x] `npx tsx src/server/cli/server.ts` starts and stays running (verified with health check after 15s).
- [x] `curl -X POST http://localhost:8000/api/v1/memories -d '{"content":"test"}' -H 'Content-Type: application/json'` returns 200 with siliconflow embeddings.
- [x] `npm run type-check` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 649 passed, 2 skipped (identical to before fix)

## Checklist

- [x] Issue acceptance criteria met
- [x] No unrelated files included (single file change: `src/server/cli/server.ts`)
- [x] No dependencies on other PRs
