### PR TITLE
feat(config): align MemoryConfig and IntelligentMemoryConfig with Python SDK

### DIFF
--- a/src/powermem/configs.ts
+++ b/src/powermem/configs.ts
@@ -11,11 +11,33 @@ export const IntelligentMemoryConfigSchema = z.object({
   enabled: z.boolean().default(true),
   plugin: z.string().default('ebbinghaus'),
   initialRetention: z.number().default(1.0),
+  // Note: TS decayRate default (0.1) intentionally differs from Python (1.5).
+  // The two are not semantically equivalent — Python's decay_rate is a base
+  // decay strength where "larger values decay slower"; TS uses decayRate as a
+  // reinforcement-style weight consumed by IntelligenceManager. See
+  // docs/migration/deep-feature-gap-matrix.md §8 decision D1.
   decayRate: z.number().default(0.1),
+  // New in round 4 (parity with Python configs.py:43): per-memory-type
+  // multipliers on base decay_rate. Reserved for future EbbinghausAlgorithm
+  // alignment; current TS code does not yet consume it.
+  decayRateMultipliers: z.record(z.string(), z.number()).default({
+    working: 1,
+    short_term: 7,
+    long_term: 60,
+  }),
   reinforcementFactor: z.number().default(0.3),
+  // New in round 4 (parity with Python configs.py:58): multiplier applied to
+  // search ranking scores for memories marked should_forget.
+  forgottenScoreMultiplier: z.number().default(0.1),
   workingThreshold: z.number().default(0.3),
   shortTermThreshold: z.number().default(0.6),
   longTermThreshold: z.number().default(0.8),
+  // New in round 4 (parity with Python configs.py:77): how strongly importance
+  // shortens review intervals (0-1 scale).
+  reviewAdjustmentFactor: z.number().default(0.3),
+  // New in round 4 (parity with Python configs.py:81): minimum hours between
+  // scheduled reviews.
+  reviewIntervalMinHours: z.number().default(0.5),
   fallbackToSimpleAdd: z.boolean().default(false),
 });
 export type IntelligentMemoryConfig = z.infer<typeof IntelligentMemoryConfigSchema>;
@@ -154,15 +176,41 @@ export const SparseEmbedderProviderConfigSchema = z.object({
 });
 export type SparseEmbedderProviderConfig = z.infer<typeof SparseEmbedderProviderConfigSchema>;
 
+// ─── Skill / Source store configs (round 4, parity with Python configs.py:229/237) ────
+
+export const SkillStoreConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  collectionName: z.string().nullish(),
+  similarityThreshold: z.number().default(0.03),
+  indexType: z.string().nullish(),
+});
+export type SkillStoreConfig = z.infer<typeof SkillStoreConfigSchema>;
+
+export const SourceStoreConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  collectionName: z.string().nullish(),
+});
+export type SourceStoreConfig = z.infer<typeof SourceStoreConfigSchema>;
+
 // ─── Main config ──────────────────────────────────────────────────────────
 
 export const MemoryConfigSchema = z.object({
   vectorStore: VectorStoreProviderConfigSchema.default(() => ({ provider: 'seekdb', config: {} })),
   llm: LLMProviderConfigSchema.default(() => ({ provider: 'qwen', config: {} })),
   embedder: EmbedderProviderConfigSchema.default(() => ({ provider: 'qwen', config: {} })),
+  // New in round 4 (parity with Python configs.py:321): optional audio LLM
+  // provider for ASR / audio transcription. Schema mirrors `llm` so that
+  // existing factory functions can be reused.
+  audioLlm: LLMProviderConfigSchema.nullish(),
   graphStore: GraphStoreProviderConfigSchema.nullish(),
   reranker: RerankProviderConfigSchema.nullish(),
   sparseEmbedder: SparseEmbedderProviderConfigSchema.nullish(),
+  // New in round 4 (parity with Python configs.py:329/333): skill_store and
+  // source_store are OceanBase-only features in Python; TS exposes the config
+  // schema so users can opt in, but the actual stores remain stubs (see
+  // Memory.sourceStoreEnabled / skill store methods).
+  skillStore: SkillStoreConfigSchema.nullish(),
+  sourceStore: SourceStoreConfigSchema.nullish(),
   version: z.string().default('v1.1'),
   customFactExtractionPrompt: z.string().nullish(),
   customUpdateMemoryPrompt: z.string().nullish(),

--- a/src/powermem/types/options.ts
+++ b/src/powermem/types/options.ts
@@ -4,6 +4,8 @@ import type { SearchHit } from './responses.js';
 import type { MemoryConfigInput } from '../configs.js';
 import type { GraphStoreBase, VectorStore } from '../storage/base.js';
 import type { SubStorageRouter } from '../storage/sub-storage.js';
+import type { SourceStoreBase } from '../storage/source_store/base.js';
+import type { SkillStoreBase } from '../storage/skill_store/base.js';
 
 /** Reranker function: re-scores/reorders search hits after cosine similarity. */
 export type RerankerFn = (
@@ -26,4 +28,8 @@ export interface MemoryOptions {
   decayWeight?: number;
   graphStore?: GraphStoreBase;
   subStorageRouter?: SubStorageRouter;
+  /** Round 5: optional source store. When omitted, Memory's source-store methods return stub values (parity with Python disabled mode). */
+  sourceStore?: SourceStoreBase;
+  /** Round 5: optional skill store. When omitted, Memory's skill-store methods return stub values (parity with Python disabled mode). */
+  skillStore?: SkillStoreBase;
 }

--- a/src/powermem/types/options.ts
+++ b/src/powermem/types/options.ts
@@ -4,8 +4,22 @@ import type { SearchHit } from './responses.js';
 import type { MemoryConfigInput } from '../configs.js';
 import type { GraphStoreBase, VectorStore } from '../storage/base.js';
 import type { SubStorageRouter } from '../storage/sub-storage.js';
-import type { SourceStoreBase } from '../storage/source_store/base.js';
-import type { SkillStoreBase } from '../storage/skill_store/base.js';
+
+/**
+ * Minimal placeholder interfaces for source/skill store injection.
+ * Full definitions live in `storage/source_store/base.ts` and
+ * `storage/skill_store/base.ts` (landed in PR-3). Using inline
+ * placeholders here avoids a hard dependency on those files.
+ */
+export interface SourceStoreBase {
+  createTable(): Promise<void>;
+  close(): Promise<void>;
+}
+
+export interface SkillStoreBase {
+  createTable(): Promise<void>;
+  close(): Promise<void>;
+}
 
 /** Reranker function: re-scores/reorders search hits after cosine similarity. */
 export type RerankerFn = (
@@ -28,8 +42,8 @@ export interface MemoryOptions {
   decayWeight?: number;
   graphStore?: GraphStoreBase;
   subStorageRouter?: SubStorageRouter;
-  /** Round 5: optional source store. When omitted, Memory's source-store methods return stub values (parity with Python disabled mode). */
+  /** Optional source store. When omitted, Memory's source-store methods return stub values (parity with Python disabled mode). */
   sourceStore?: SourceStoreBase;
-  /** Round 5: optional skill store. When omitted, Memory's skill-store methods return stub values (parity with Python disabled mode). */
+  /** Optional skill store. When omitted, Memory's skill-store methods return stub values (parity with Python disabled mode). */
   skillStore?: SkillStoreBase;
 }


### PR DESCRIPTION
## Description

Implements config schema parity required by SourceStore, SkillStore, and intelligence features.

## Related Issues

Closes #30

## Changes

- Extend `IntelligentMemoryConfig` with missing Python-aligned fields (`decayRateMultipliers`, `forgottenScoreMultiplier`, `reviewAdjustmentFactor`, `reviewIntervalMinHours`).
- Add `audioLlm`, `skillStore`, `sourceStore` to top-level `MemoryConfig`.
- Add `SkillStoreConfigSchema` and `SourceStoreConfigSchema`.
- Update `types/options.ts` with `sourceStore` and `skillStore` optional fields in `MemoryOptions`.

## Test Plan

- [x] `npm run type-check`
- [x] `npm test` (649 passed, 2 skipped)
- [x] `npm run build`

## Checklist

- [x] Issue acceptance criteria met
- [x] No unrelated files included
- [x] Intentional default divergences unchanged
