### PR TITLE
feat(storage): implement SQLite SourceStore and SkillStore backends

### DIFF
--- a/src/powermem/configs.ts
+++ b/src/powermem/configs.ts
@@ -11,11 +11,33 @@ export const IntelligentMemoryConfigSchema = z.object({
   enabled: z.boolean().default(true),
   plugin: z.string().default('ebbinghaus'),
   initialRetention: z.number().default(1.0),
+  // Note: TS decayRate default (0.1) intentionally differs from Python (1.5).
+  // The two are not semantically equivalent — Python's decay_rate is a base
+  // decay strength where "larger values decay slower"; TS uses decayRate as a
+  // reinforcement-style weight consumed by IntelligenceManager. See
+  // docs/migration/deep-feature-gap-matrix.md §8 decision D1.
   decayRate: z.number().default(0.1),
+  // New in round 4 (parity with Python configs.py:43): per-memory-type
+  // multipliers on base decay_rate. Reserved for future EbbinghausAlgorithm
+  // alignment; current TS code does not yet consume it.
+  decayRateMultipliers: z.record(z.string(), z.number()).default({
+    working: 1,
+    short_term: 7,
+    long_term: 60,
+  }),
   reinforcementFactor: z.number().default(0.3),
+  // New in round 4 (parity with Python configs.py:58): multiplier applied to
+  // search ranking scores for memories marked should_forget.
+  forgottenScoreMultiplier: z.number().default(0.1),
   workingThreshold: z.number().default(0.3),
   shortTermThreshold: z.number().default(0.6),
   longTermThreshold: z.number().default(0.8),
+  // New in round 4 (parity with Python configs.py:77): how strongly importance
+  // shortens review intervals (0-1 scale).
+  reviewAdjustmentFactor: z.number().default(0.3),
+  // New in round 4 (parity with Python configs.py:81): minimum hours between
+  // scheduled reviews.
+  reviewIntervalMinHours: z.number().default(0.5),
   fallbackToSimpleAdd: z.boolean().default(false),
 });
 export type IntelligentMemoryConfig = z.infer<typeof IntelligentMemoryConfigSchema>;
@@ -154,15 +176,41 @@ export const SparseEmbedderProviderConfigSchema = z.object({
 });
 export type SparseEmbedderProviderConfig = z.infer<typeof SparseEmbedderProviderConfigSchema>;
 
+// ─── Skill / Source store configs (round 4, parity with Python configs.py:229/237) ────
+
+export const SkillStoreConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  collectionName: z.string().nullish(),
+  similarityThreshold: z.number().default(0.03),
+  indexType: z.string().nullish(),
+});
+export type SkillStoreConfig = z.infer<typeof SkillStoreConfigSchema>;
+
+export const SourceStoreConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  collectionName: z.string().nullish(),
+});
+export type SourceStoreConfig = z.infer<typeof SourceStoreConfigSchema>;
+
 // ─── Main config ──────────────────────────────────────────────────────────
 
 export const MemoryConfigSchema = z.object({
   vectorStore: VectorStoreProviderConfigSchema.default(() => ({ provider: 'seekdb', config: {} })),
   llm: LLMProviderConfigSchema.default(() => ({ provider: 'qwen', config: {} })),
   embedder: EmbedderProviderConfigSchema.default(() => ({ provider: 'qwen', config: {} })),
+  // New in round 4 (parity with Python configs.py:321): optional audio LLM
+  // provider for ASR / audio transcription. Schema mirrors `llm` so that
+  // existing factory functions can be reused.
+  audioLlm: LLMProviderConfigSchema.nullish(),
   graphStore: GraphStoreProviderConfigSchema.nullish(),
   reranker: RerankProviderConfigSchema.nullish(),
   sparseEmbedder: SparseEmbedderProviderConfigSchema.nullish(),
+  // New in round 4 (parity with Python configs.py:329/333): skill_store and
+  // source_store are OceanBase-only features in Python; TS exposes the config
+  // schema so users can opt in, but the actual stores remain stubs (see
+  // Memory.sourceStoreEnabled / skill store methods).
+  skillStore: SkillStoreConfigSchema.nullish(),
+  sourceStore: SourceStoreConfigSchema.nullish(),
   version: z.string().default('v1.1'),
   customFactExtractionPrompt: z.string().nullish(),
   customUpdateMemoryPrompt: z.string().nullish(),

--- a/src/powermem/storage/base.ts
+++ b/src/powermem/storage/base.ts
@@ -74,6 +74,17 @@ export interface VectorStore {
   incrementAccessCountBatch(ids: string[]): Promise<void>;
   removeAll(filters?: VectorStoreFilter): Promise<void>;
   close(): Promise<void>;
+  // ─── Optional DDL methods (round 4 parity with Python VectorStoreBase) ────
+  // These are optional in TS because not all backends (e.g. embedded SQLite
+  // with auto-created tables) need explicit DDL. Python's VectorStoreBase
+  // (storage/base.py:18) requires them; TS leaves them as optional so
+  // concrete stores can opt in. Memory.reset() checks `typeof store.reset`
+  // before invoking.
+  createCol?(): Promise<void>;
+  listCols?(): Promise<string[]>;
+  deleteCol?(): Promise<void>;
+  colInfo?(): Promise<Record<string, unknown>>;
+  reset?(): Promise<void>;
 }
 
 /**

--- a/src/powermem/storage/skill_store/base.ts
+++ b/src/powermem/storage/skill_store/base.ts
@@ -1,0 +1,74 @@
+/**
+ * SkillStoreBase — abstract interface for skill storage backends.
+ * Round 5 port of Python `storage/skill_store/base.py`.
+ */
+export interface SkillRecord {
+  id: string;
+  title: string;
+  description: string;
+  tags?: string[];
+  procedureData?: Record<string, unknown>;
+  titleEmbedding?: number[];
+  descriptionEmbedding?: number[];
+  userId?: string;
+  agentId?: string;
+  status?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SkillSearchParams {
+  queryEmbedding?: number[];
+  queryText?: string;
+  limit?: number;
+  userId?: string;
+  agentId?: string;
+  statusFilter?: string;
+}
+
+export interface SkillSearchHit extends SkillRecord {
+  score: number;
+}
+
+export interface SkillStoreBase {
+  /** Create the skills table if it doesn't exist. */
+  createTable(): Promise<void>;
+
+  /** Insert a skill. Returns the stored record (with assigned id). */
+  add(params: {
+    title: string;
+    description: string;
+    tags?: string[];
+    procedureData?: Record<string, unknown>;
+    titleEmbedding?: number[];
+    descriptionEmbedding?: number[];
+    userId?: string;
+    agentId?: string;
+  }): Promise<SkillRecord>;
+
+  /** Update an existing skill. Returns true on success. */
+  update(params: {
+    skillId: string;
+    title?: string;
+    description?: string;
+    tags?: string[];
+    procedureData?: Record<string, unknown>;
+    titleEmbedding?: number[];
+    descriptionEmbedding?: number[];
+  }): Promise<boolean>;
+
+  /** Get a single skill by ID. Returns null when not found. */
+  get(skillId: string): Promise<SkillRecord | null>;
+
+  /** Search skills by embedding and/or fulltext. Returns list with scores. */
+  search(params: SkillSearchParams): Promise<SkillSearchHit[]>;
+
+  /** Update the status of a skill. Returns true if the row was changed. */
+  updateStatus(skillId: string, status: string): Promise<boolean>;
+
+  /** Delete a skill by ID. Returns true on success. */
+  delete(skillId: string): Promise<boolean>;
+
+  /** Release resources held by this store. */
+  close(): Promise<void>;
+}

--- a/src/powermem/storage/skill_store/sqlite.ts
+++ b/src/powermem/storage/skill_store/sqlite.ts
@@ -1,0 +1,246 @@
+/**
+ * SQLiteSkillStore — SQLite-backed implementation of SkillStoreBase.
+ *
+ * Round 5 implementation. Python upstream ships an OceanBase-only concrete
+ * implementation; TS ships a portable SQLite-backed implementation so skill
+ * creation / search / status update can be exercised locally without a real
+ * OceanBase cluster. OceanBase parity is provided via the abstract
+ * SkillStoreBase interface.
+ *
+ * Schema:
+ *   - skills(id, title, description, tags, procedure_data, title_vector,
+ *            description_vector, user_id, agent_id, status, created_at,
+ *            updated_at)
+ *
+ * Search supports both vector (cosine similarity over title_vector) and
+ * fulltext (LIKE over title + description) modes.
+ */
+import Database from 'better-sqlite3';
+import { cosineSimilarity } from '../../utils/search.js';
+import type { SkillRecord, SkillSearchParams, SkillSearchHit, SkillStoreBase } from './base.js';
+
+interface SkillRow {
+  id: string;
+  title: string;
+  description: string;
+  tags: string | null;
+  procedure_data: string | null;
+  title_vector: string | null;
+  description_vector: string | null;
+  user_id: string | null;
+  agent_id: string | null;
+  status: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToRecord(row: SkillRow): SkillRecord {
+  return {
+    id: String(row.id),
+    title: row.title,
+    description: row.description,
+    tags: row.tags ? (JSON.parse(row.tags) as string[]) : undefined,
+    procedureData: row.procedure_data ? (JSON.parse(row.procedure_data) as Record<string, unknown>) : undefined,
+    titleEmbedding: row.title_vector ? (JSON.parse(row.title_vector) as number[]) : undefined,
+    descriptionEmbedding: row.description_vector ? (JSON.parse(row.description_vector) as number[]) : undefined,
+    userId: row.user_id ?? undefined,
+    agentId: row.agent_id ?? undefined,
+    status: row.status ?? undefined,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export interface SQLiteSkillStoreOptions {
+  db?: Database.Database;
+  path?: string;
+}
+
+export class SQLiteSkillStore implements SkillStoreBase {
+  private readonly db: Database.Database;
+  private readonly ownsDb: boolean;
+
+  constructor(options: SQLiteSkillStoreOptions = {}) {
+    if (options.db) {
+      this.db = options.db;
+      this.ownsDb = false;
+    } else {
+      this.db = new Database(options.path ?? ':memory:');
+      this.ownsDb = true;
+    }
+    this.migrate();
+  }
+
+  private migrate(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS skills (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        description TEXT NOT NULL,
+        tags TEXT,
+        procedure_data TEXT,
+        title_vector TEXT,
+        description_vector TEXT,
+        user_id TEXT,
+        agent_id TEXT,
+        status TEXT DEFAULT 'active',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_skills_user ON skills(user_id);
+      CREATE INDEX IF NOT EXISTS idx_skills_agent ON skills(agent_id);
+      CREATE INDEX IF NOT EXISTS idx_skills_status ON skills(status);
+    `);
+  }
+
+  async createTable(): Promise<void> {
+    // Migration runs in the constructor.
+  }
+
+  async add(params: {
+    title: string;
+    description: string;
+    tags?: string[];
+    procedureData?: Record<string, unknown>;
+    titleEmbedding?: number[];
+    descriptionEmbedding?: number[];
+    userId?: string;
+    agentId?: string;
+  }): Promise<SkillRecord> {
+    const id = `skill_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+    const now = new Date().toISOString();
+    this.db.prepare(`
+      INSERT INTO skills (id, title, description, tags, procedure_data, title_vector, description_vector, user_id, agent_id, status, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)
+    `).run(
+      id,
+      params.title,
+      params.description,
+      params.tags ? JSON.stringify(params.tags) : null,
+      params.procedureData ? JSON.stringify(params.procedureData) : null,
+      params.titleEmbedding ? JSON.stringify(params.titleEmbedding) : null,
+      params.descriptionEmbedding ? JSON.stringify(params.descriptionEmbedding) : null,
+      params.userId ?? null,
+      params.agentId ?? null,
+      now,
+      now,
+    );
+    return {
+      id,
+      title: params.title,
+      description: params.description,
+      tags: params.tags,
+      procedureData: params.procedureData,
+      titleEmbedding: params.titleEmbedding,
+      descriptionEmbedding: params.descriptionEmbedding,
+      userId: params.userId,
+      agentId: params.agentId,
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  async update(params: {
+    skillId: string;
+    title?: string;
+    description?: string;
+    tags?: string[];
+    procedureData?: Record<string, unknown>;
+    titleEmbedding?: number[];
+    descriptionEmbedding?: number[];
+  }): Promise<boolean> {
+    const existing = await this.get(params.skillId);
+    if (!existing) return false;
+    const now = new Date().toISOString();
+    const title = params.title ?? existing.title;
+    const description = params.description ?? existing.description;
+    const tags = params.tags ?? existing.tags;
+    const procedureData = params.procedureData ?? existing.procedureData;
+    const titleVector = params.titleEmbedding ?? existing.titleEmbedding;
+    const descVector = params.descriptionEmbedding ?? existing.descriptionEmbedding;
+    const info = this.db.prepare(`
+      UPDATE skills
+      SET title = ?, description = ?, tags = ?, procedure_data = ?,
+          title_vector = ?, description_vector = ?, updated_at = ?
+      WHERE id = ?
+    `).run(
+      title,
+      description,
+      tags ? JSON.stringify(tags) : null,
+      procedureData ? JSON.stringify(procedureData) : null,
+      titleVector ? JSON.stringify(titleVector) : null,
+      descVector ? JSON.stringify(descVector) : null,
+      now,
+      params.skillId,
+    );
+    return info.changes > 0;
+  }
+
+  async get(skillId: string): Promise<SkillRecord | null> {
+    const row = this.db.prepare('SELECT * FROM skills WHERE id = ?').get(skillId) as SkillRow | undefined;
+    return row ? rowToRecord(row) : null;
+  }
+
+  async search(params: SkillSearchParams): Promise<SkillSearchHit[]> {
+    const limit = params.limit ?? 10;
+    const conditions: string[] = [];
+    const sqlParams: unknown[] = [];
+    if (params.userId) {
+      conditions.push('user_id = ?');
+      sqlParams.push(params.userId);
+    }
+    if (params.agentId) {
+      conditions.push('agent_id = ?');
+      sqlParams.push(params.agentId);
+    }
+    if (params.statusFilter) {
+      conditions.push('status = ?');
+      sqlParams.push(params.statusFilter);
+    }
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const rows = this.db.prepare(`SELECT * FROM skills ${where}`).all(...sqlParams) as SkillRow[];
+
+    let hits: SkillSearchHit[] = rows.map((row) => ({ ...rowToRecord(row), score: 0 }));
+
+    // Vector scoring
+    if (params.queryEmbedding) {
+      const queryVec = params.queryEmbedding;
+      hits = hits.map((h) => {
+        const storedVec = h.titleEmbedding;
+        const score = storedVec ? cosineSimilarity(queryVec, storedVec) : 0;
+        return { ...h, score };
+      });
+    }
+
+    // Fulltext scoring on top (additive)
+    if (params.queryText) {
+      const q = params.queryText.toLowerCase();
+      hits = hits.map((h) => {
+        const text = `${h.title} ${h.description}`.toLowerCase();
+        const match = text.includes(q) ? 0.1 : 0;
+        return { ...h, score: h.score + match };
+      });
+    }
+
+    hits.sort((a, b) => b.score - a.score);
+    return hits.slice(0, limit);
+  }
+
+  async updateStatus(skillId: string, status: string): Promise<boolean> {
+    const now = new Date().toISOString();
+    const info = this.db.prepare(`
+      UPDATE skills SET status = ?, updated_at = ? WHERE id = ?
+    `).run(status, now, skillId);
+    return info.changes > 0;
+  }
+
+  async delete(skillId: string): Promise<boolean> {
+    const info = this.db.prepare('DELETE FROM skills WHERE id = ?').run(skillId);
+    return info.changes > 0;
+  }
+
+  async close(): Promise<void> {
+    if (this.ownsDb) this.db.close();
+  }
+}

--- a/src/powermem/storage/source_store/base.ts
+++ b/src/powermem/storage/source_store/base.ts
@@ -1,0 +1,81 @@
+/**
+ * SourceStoreBase — abstract interface for source storage (fact-source
+ * linking). Round 5 port of Python `storage/source_store/base.py`.
+ *
+ * A *source* represents the origin of one or more downstream records — for
+ * example a conversation turn, a file upload, or an API call. Each memory /
+ * skill record can optionally reference the source it was extracted from via
+ * a dedicated link table.
+ */
+export interface SourceRecord {
+  id: string;
+  sourceType: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+  userId?: string;
+  agentId?: string;
+  runId?: string;
+  actorId?: string;
+  createdAt: string;
+}
+
+export interface SourceStoreBase {
+  /** Create the sources + link tables if they do not exist. */
+  createTable(): Promise<void>;
+
+  /**
+   * Insert a source record. The four scope columns mirror the scope
+   * dimensions on the main memory table so that sources can be queried /
+   * purged along the same axes as the records they spawn.
+   */
+  createSource(params: {
+    sourceType: string;
+    content: string;
+    metadata?: Record<string, unknown>;
+    userId?: string;
+    agentId?: string;
+    runId?: string;
+    actorId?: string;
+  }): Promise<SourceRecord>;
+
+  /** Retrieve a source by its primary key. Returns null when not found. */
+  getSource(sourceId: string): Promise<SourceRecord | null>;
+
+  // ─── Memory linking ────────────────────────────────────────────────────
+
+  /**
+   * Create a link between a source and a memory record. Idempotent on
+   * (sourceId, memoryId). Returns true if a new link was created; false if
+   * the link already existed.
+   */
+  linkMemory(sourceId: string, memoryId: string): Promise<boolean>;
+
+  /**
+   * Remove a link between a source and a memory record. Returns true if a
+   * link was actually removed.
+   */
+  unlinkMemory(sourceId: string, memoryId: string): Promise<boolean>;
+
+  /** Return all sources linked to a given memory record. */
+  getSourcesForMemory(memoryId: string): Promise<SourceRecord[]>;
+
+  // ─── Skill linking ─────────────────────────────────────────────────────
+
+  linkSkill(sourceId: string, skillId: string): Promise<boolean>;
+  unlinkSkill(sourceId: string, skillId: string): Promise<boolean>;
+  getSourcesForSkill(skillId: string): Promise<SourceRecord[]>;
+
+  // ─── Reverse queries ───────────────────────────────────────────────────
+
+  /** Return all memory IDs linked to a given source. */
+  getMemoriesForSource(sourceId: string): Promise<string[]>;
+
+  /** Return all skill IDs linked to a given source. */
+  getSkillsForSource(sourceId: string): Promise<string[]>;
+
+  /** Delete a source and all its memory/skill links. Returns true on success. */
+  deleteSource(sourceId: string): Promise<boolean>;
+
+  /** Release resources held by this store. */
+  close(): Promise<void>;
+}

--- a/src/powermem/storage/source_store/sqlite.ts
+++ b/src/powermem/storage/source_store/sqlite.ts
@@ -1,0 +1,230 @@
+/**
+ * SQLiteSourceStore — SQLite-backed implementation of SourceStoreBase.
+ *
+ * Round 5 implementation. The Python upstream ships an OceanBase-only
+ * concrete implementation; TS ships a portable SQLite-backed implementation
+ * so source linking can be exercised locally without a real OceanBase
+ * cluster. OceanBase parity is provided via the abstract SourceStoreBase
+ * interface — any future OceanBase implementation only needs to satisfy the
+ * same contract.
+ *
+ * Schema (matches Python source_store/oceanbase.py intent):
+ *   - sources(id, source_type, content, metadata, user_id, agent_id,
+ *             run_id, actor_id, created_at)
+ *   - source_memory_links(source_id, memory_id, PRIMARY KEY(source_id, memory_id))
+ *   - source_skill_links(source_id, skill_id,  PRIMARY KEY(source_id, skill_id))
+ */
+import Database from 'better-sqlite3';
+import type { SourceRecord, SourceStoreBase } from './base.js';
+
+interface SourceRow {
+  id: string;
+  source_type: string;
+  content: string;
+  metadata: string | null;
+  user_id: string | null;
+  agent_id: string | null;
+  run_id: string | null;
+  actor_id: string | null;
+  created_at: string;
+}
+
+function rowToRecord(row: SourceRow): SourceRecord {
+  return {
+    id: String(row.id),
+    sourceType: row.source_type,
+    content: row.content,
+    metadata: row.metadata ? (JSON.parse(row.metadata) as Record<string, unknown>) : undefined,
+    userId: row.user_id ?? undefined,
+    agentId: row.agent_id ?? undefined,
+    runId: row.run_id ?? undefined,
+    actorId: row.actor_id ?? undefined,
+    createdAt: row.created_at,
+  };
+}
+
+export interface SQLiteSourceStoreOptions {
+  /** better-sqlite3 Database instance to reuse (e.g. shared with SQLiteStore). */
+  db?: Database.Database;
+  /** File path; defaults to ':memory:'. Ignored when `db` is provided. */
+  path?: string;
+}
+
+export class SQLiteSourceStore implements SourceStoreBase {
+  private readonly db: Database.Database;
+  private readonly ownsDb: boolean;
+
+  constructor(options: SQLiteSourceStoreOptions = {}) {
+    if (options.db) {
+      this.db = options.db;
+      this.ownsDb = false;
+    } else {
+      this.db = new Database(options.path ?? ':memory:');
+      this.ownsDb = true;
+    }
+    this.migrate();
+  }
+
+  private migrate(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS sources (
+        id TEXT PRIMARY KEY,
+        source_type TEXT NOT NULL,
+        content TEXT NOT NULL,
+        metadata TEXT,
+        user_id TEXT,
+        agent_id TEXT,
+        run_id TEXT,
+        actor_id TEXT,
+        created_at TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS source_memory_links (
+        source_id TEXT NOT NULL,
+        memory_id TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (source_id, memory_id)
+      );
+      CREATE TABLE IF NOT EXISTS source_skill_links (
+        source_id TEXT NOT NULL,
+        skill_id TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (source_id, skill_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_sources_user ON sources(user_id);
+      CREATE INDEX IF NOT EXISTS idx_sources_agent ON sources(agent_id);
+      CREATE INDEX IF NOT EXISTS idx_sources_run ON sources(run_id);
+      CREATE INDEX IF NOT EXISTS idx_links_memory ON source_memory_links(memory_id);
+      CREATE INDEX IF NOT EXISTS idx_links_skill ON source_skill_links(skill_id);
+    `);
+  }
+
+  async createTable(): Promise<void> {
+    // Migration runs in the constructor; this method exists to honour the
+    // SourceStoreBase contract for parity with Python `create_table()`.
+  }
+
+  async createSource(params: {
+    sourceType: string;
+    content: string;
+    metadata?: Record<string, unknown>;
+    userId?: string;
+    agentId?: string;
+    runId?: string;
+    actorId?: string;
+  }): Promise<SourceRecord> {
+    const id = `src_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+    const createdAt = new Date().toISOString();
+    this.db.prepare(`
+      INSERT INTO sources (id, source_type, content, metadata, user_id, agent_id, run_id, actor_id, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      id,
+      params.sourceType,
+      params.content,
+      params.metadata ? JSON.stringify(params.metadata) : null,
+      params.userId ?? null,
+      params.agentId ?? null,
+      params.runId ?? null,
+      params.actorId ?? null,
+      createdAt,
+    );
+    return {
+      id,
+      sourceType: params.sourceType,
+      content: params.content,
+      metadata: params.metadata,
+      userId: params.userId,
+      agentId: params.agentId,
+      runId: params.runId,
+      actorId: params.actorId,
+      createdAt,
+    };
+  }
+
+  async getSource(sourceId: string): Promise<SourceRecord | null> {
+    const row = this.db.prepare('SELECT * FROM sources WHERE id = ?').get(sourceId) as SourceRow | undefined;
+    return row ? rowToRecord(row) : null;
+  }
+
+  async linkMemory(sourceId: string, memoryId: string): Promise<boolean> {
+    const createdAt = new Date().toISOString();
+    const info = this.db.prepare(`
+      INSERT OR IGNORE INTO source_memory_links (source_id, memory_id, created_at)
+      VALUES (?, ?, ?)
+    `).run(sourceId, memoryId, createdAt);
+    return info.changes > 0;
+  }
+
+  async unlinkMemory(sourceId: string, memoryId: string): Promise<boolean> {
+    const info = this.db.prepare(`
+      DELETE FROM source_memory_links WHERE source_id = ? AND memory_id = ?
+    `).run(sourceId, memoryId);
+    return info.changes > 0;
+  }
+
+  async getSourcesForMemory(memoryId: string): Promise<SourceRecord[]> {
+    const rows = this.db.prepare(`
+      SELECT s.* FROM sources s
+      JOIN source_memory_links l ON l.source_id = s.id
+      WHERE l.memory_id = ?
+      ORDER BY l.created_at ASC
+    `).all(memoryId) as SourceRow[];
+    return rows.map(rowToRecord);
+  }
+
+  async linkSkill(sourceId: string, skillId: string): Promise<boolean> {
+    const createdAt = new Date().toISOString();
+    const info = this.db.prepare(`
+      INSERT OR IGNORE INTO source_skill_links (source_id, skill_id, created_at)
+      VALUES (?, ?, ?)
+    `).run(sourceId, skillId, createdAt);
+    return info.changes > 0;
+  }
+
+  async unlinkSkill(sourceId: string, skillId: string): Promise<boolean> {
+    const info = this.db.prepare(`
+      DELETE FROM source_skill_links WHERE source_id = ? AND skill_id = ?
+    `).run(sourceId, skillId);
+    return info.changes > 0;
+  }
+
+  async getSourcesForSkill(skillId: string): Promise<SourceRecord[]> {
+    const rows = this.db.prepare(`
+      SELECT s.* FROM sources s
+      JOIN source_skill_links l ON l.source_id = s.id
+      WHERE l.skill_id = ?
+      ORDER BY l.created_at ASC
+    `).all(skillId) as SourceRow[];
+    return rows.map(rowToRecord);
+  }
+
+  async getMemoriesForSource(sourceId: string): Promise<string[]> {
+    const rows = this.db.prepare(`
+      SELECT memory_id FROM source_memory_links WHERE source_id = ?
+      ORDER BY created_at ASC
+    `).all(sourceId) as Array<{ memory_id: string }>;
+    return rows.map((r) => r.memory_id);
+  }
+
+  async getSkillsForSource(sourceId: string): Promise<string[]> {
+    const rows = this.db.prepare(`
+      SELECT skill_id FROM source_skill_links WHERE source_id = ?
+      ORDER BY created_at ASC
+    `).all(sourceId) as Array<{ skill_id: string }>;
+    return rows.map((r) => r.skill_id);
+  }
+
+  async deleteSource(sourceId: string): Promise<boolean> {
+    const info = this.db.prepare('DELETE FROM sources WHERE id = ?').run(sourceId);
+    if (info.changes > 0) {
+      this.db.prepare('DELETE FROM source_memory_links WHERE source_id = ?').run(sourceId);
+      this.db.prepare('DELETE FROM source_skill_links WHERE source_id = ?').run(sourceId);
+      return true;
+    }
+    return false;
+  }
+
+  async close(): Promise<void> {
+    if (this.ownsDb) this.db.close();
+  }
+}

--- a/src/powermem/types/options.ts
+++ b/src/powermem/types/options.ts
@@ -4,6 +4,8 @@ import type { SearchHit } from './responses.js';
 import type { MemoryConfigInput } from '../configs.js';
 import type { GraphStoreBase, VectorStore } from '../storage/base.js';
 import type { SubStorageRouter } from '../storage/sub-storage.js';
+import type { SourceStoreBase } from '../storage/source_store/base.js';
+import type { SkillStoreBase } from '../storage/skill_store/base.js';
 
 /** Reranker function: re-scores/reorders search hits after cosine similarity. */
 export type RerankerFn = (
@@ -26,4 +28,8 @@ export interface MemoryOptions {
   decayWeight?: number;
   graphStore?: GraphStoreBase;
   subStorageRouter?: SubStorageRouter;
+  /** Round 5: optional source store. When omitted, Memory's source-store methods return stub values (parity with Python disabled mode). */
+  sourceStore?: SourceStoreBase;
+  /** Round 5: optional skill store. When omitted, Memory's skill-store methods return stub values (parity with Python disabled mode). */
+  skillStore?: SkillStoreBase;
 }

--- a/src/powermem/types/options.ts
+++ b/src/powermem/types/options.ts
@@ -4,8 +4,22 @@ import type { SearchHit } from './responses.js';
 import type { MemoryConfigInput } from '../configs.js';
 import type { GraphStoreBase, VectorStore } from '../storage/base.js';
 import type { SubStorageRouter } from '../storage/sub-storage.js';
-import type { SourceStoreBase } from '../storage/source_store/base.js';
-import type { SkillStoreBase } from '../storage/skill_store/base.js';
+
+/**
+ * Minimal placeholder interfaces for source/skill store injection.
+ * Full definitions live in `storage/source_store/base.ts` and
+ * `storage/skill_store/base.ts` (landed in PR-3). Using inline
+ * placeholders here avoids a hard dependency on those files.
+ */
+export interface SourceStoreBase {
+  createTable(): Promise<void>;
+  close(): Promise<void>;
+}
+
+export interface SkillStoreBase {
+  createTable(): Promise<void>;
+  close(): Promise<void>;
+}
 
 /** Reranker function: re-scores/reorders search hits after cosine similarity. */
 export type RerankerFn = (
@@ -28,8 +42,8 @@ export interface MemoryOptions {
   decayWeight?: number;
   graphStore?: GraphStoreBase;
   subStorageRouter?: SubStorageRouter;
-  /** Round 5: optional source store. When omitted, Memory's source-store methods return stub values (parity with Python disabled mode). */
+  /** Optional source store. When omitted, Memory's source-store methods return stub values (parity with Python disabled mode). */
   sourceStore?: SourceStoreBase;
-  /** Round 5: optional skill store. When omitted, Memory's skill-store methods return stub values (parity with Python disabled mode). */
+  /** Optional skill store. When omitted, Memory's skill-store methods return stub values (parity with Python disabled mode). */
   skillStore?: SkillStoreBase;
 }

--- a/tests/parity/source-skill-store.test.ts
+++ b/tests/parity/source-skill-store.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Parity tests: round 5 SQLiteSourceStore + SQLiteSkillStore real implementations.
+ *
+ * Validates that the abstract SourceStoreBase / SkillStoreBase contracts work
+ * end-to-end against the SQLite backend without needing OceanBase. The same
+ * tests will pass against any future OceanBase implementation that satisfies
+ * the same contract.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { SQLiteSourceStore } from '../../src/powermem/storage/source_store/sqlite.js';
+import { SQLiteSkillStore } from '../../src/powermem/storage/skill_store/sqlite.js';
+
+describe('parity / SQLiteSourceStore (round 5 real impl)', () => {
+  let store: SQLiteSourceStore | undefined;
+
+  afterEach(async () => {
+    if (store) await store.close();
+    store = undefined;
+  });
+
+  it('createSource + getSource roundtrip', async () => {
+    store = new SQLiteSourceStore();
+    const created = await store.createSource({
+      sourceType: 'conversation',
+      content: 'user asked about deployment',
+      userId: 'u1',
+      agentId: 'a1',
+      metadata: { turn: 3 },
+    });
+    expect(created.id).toBeTruthy();
+    expect(created.sourceType).toBe('conversation');
+    const fetched = await store.getSource(created.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.content).toBe('user asked about deployment');
+    expect(fetched!.metadata?.turn).toBe(3);
+  });
+
+  it('getSource returns null for non-existent id', async () => {
+    store = new SQLiteSourceStore();
+    expect(await store.getSource('no-such-source')).toBeNull();
+  });
+
+  it('linkMemory + getMemoriesForSource + unlink', async () => {
+    store = new SQLiteSourceStore();
+    const src = await store.createSource({ sourceType: 'msg', content: 'hello' });
+    expect(await store.linkMemory(src.id, 'mem-1')).toBe(true);
+    // Idempotent — second call should report false.
+    expect(await store.linkMemory(src.id, 'mem-1')).toBe(false);
+    await store.linkMemory(src.id, 'mem-2');
+    expect(await store.getMemoriesForSource(src.id)).toEqual(['mem-1', 'mem-2']);
+    expect(await store.unlinkMemory(src.id, 'mem-1')).toBe(true);
+    expect(await store.unlinkMemory(src.id, 'mem-1')).toBe(false);
+    expect(await store.getMemoriesForSource(src.id)).toEqual(['mem-2']);
+  });
+
+  it('linkSkill + getSkillsForSource', async () => {
+    store = new SQLiteSourceStore();
+    const src = await store.createSource({ sourceType: 'doc', content: 'docs' });
+    expect(await store.linkSkill(src.id, 'skill-1')).toBe(true);
+    expect(await store.linkSkill(src.id, 'skill-2')).toBe(true);
+    expect(await store.getSkillsForSource(src.id)).toEqual(['skill-1', 'skill-2']);
+  });
+
+  it('getSourcesForMemory / getSourcesForSkill return records', async () => {
+    store = new SQLiteSourceStore();
+    const src1 = await store.createSource({ sourceType: 'a', content: 'a' });
+    const src2 = await store.createSource({ sourceType: 'b', content: 'b' });
+    await store.linkMemory(src1.id, 'mem-x');
+    await store.linkMemory(src2.id, 'mem-x');
+    const sourcesForMem = await store.getSourcesForMemory('mem-x');
+    expect(sourcesForMem).toHaveLength(2);
+    expect(sourcesForMem.map((s) => s.id).sort()).toEqual([src1.id, src2.id].sort());
+  });
+
+  it('deleteSource cascades links', async () => {
+    store = new SQLiteSourceStore();
+    const src = await store.createSource({ sourceType: 'temp', content: 'tmp' });
+    await store.linkMemory(src.id, 'mem-z');
+    await store.linkSkill(src.id, 'skill-z');
+    expect(await store.deleteSource(src.id)).toBe(true);
+    expect(await store.getSource(src.id)).toBeNull();
+    expect(await store.getMemoriesForSource(src.id)).toEqual([]);
+    expect(await store.getSkillsForSource(src.id)).toEqual([]);
+  });
+
+  it('deleteSource on non-existent id returns false', async () => {
+    store = new SQLiteSourceStore();
+    expect(await store.deleteSource('no-such')).toBe(false);
+  });
+
+  it('scope columns are persisted', async () => {
+    store = new SQLiteSourceStore();
+    const src = await store.createSource({
+      sourceType: 'm',
+      content: 'c',
+      userId: 'user-1',
+      agentId: 'agent-1',
+      runId: 'run-1',
+      actorId: 'actor-1',
+    });
+    const fetched = await store.getSource(src.id);
+    expect(fetched!.userId).toBe('user-1');
+    expect(fetched!.agentId).toBe('agent-1');
+    expect(fetched!.runId).toBe('run-1');
+    expect(fetched!.actorId).toBe('actor-1');
+  });
+});
+
+describe('parity / SQLiteSkillStore (round 5 real impl)', () => {
+  let store: SQLiteSkillStore | undefined;
+
+  afterEach(async () => {
+    if (store) await store.close();
+    store = undefined;
+  });
+
+  it('add + get roundtrip', async () => {
+    store = new SQLiteSkillStore();
+    const created = await store.add({
+      title: 'Deploy app',
+      description: 'Standard deploy flow',
+      tags: ['deploy', 'ops'],
+      procedureData: { steps: ['push', 'verify'] },
+      titleEmbedding: [0.1, 0.2, 0.3],
+      userId: 'u1',
+    });
+    expect(created.id).toBeTruthy();
+    expect(created.status).toBe('active');
+    const fetched = await store.get(created.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.title).toBe('Deploy app');
+    expect(fetched!.tags).toEqual(['deploy', 'ops']);
+  });
+
+  it('get returns null for non-existent id', async () => {
+    store = new SQLiteSkillStore();
+    expect(await store.get('no-such')).toBeNull();
+  });
+
+  it('update changes title/description/tags', async () => {
+    store = new SQLiteSkillStore();
+    const created = await store.add({ title: 'old', description: 'old desc' });
+    const ok = await store.update({
+      skillId: created.id,
+      title: 'new title',
+      description: 'new desc',
+      tags: ['updated'],
+    });
+    expect(ok).toBe(true);
+    const fetched = await store.get(created.id);
+    expect(fetched!.title).toBe('new title');
+    expect(fetched!.tags).toEqual(['updated']);
+  });
+
+  it('update returns false for non-existent skill', async () => {
+    store = new SQLiteSkillStore();
+    expect(await store.update({ skillId: 'no-such', title: 'x' })).toBe(false);
+  });
+
+  it('search ranks by vector similarity', async () => {
+    store = new SQLiteSkillStore();
+    await store.add({
+      title: 'cook pasta',
+      description: 'boil water add pasta',
+      titleEmbedding: [1, 0, 0],
+    });
+    await store.add({
+      title: 'ride bike',
+      description: 'pedal forward',
+      titleEmbedding: [0, 1, 0],
+    });
+    const hits = await store.search({ queryEmbedding: [1, 0, 0], limit: 2 });
+    expect(hits).toHaveLength(2);
+    expect(hits[0].title).toBe('cook pasta');
+    expect(hits[0].score).toBeGreaterThan(hits[1].score);
+  });
+
+  it('search filters by userId', async () => {
+    store = new SQLiteSkillStore();
+    await store.add({ title: 'a', description: 'a', userId: 'u1' });
+    await store.add({ title: 'b', description: 'b', userId: 'u2' });
+    const hits = await store.search({ userId: 'u1' });
+    expect(hits).toHaveLength(1);
+    expect(hits[0].userId).toBe('u1');
+  });
+
+  it('updateStatus flips status', async () => {
+    store = new SQLiteSkillStore();
+    const created = await store.add({ title: 's', description: 's' });
+    expect(await store.updateStatus(created.id, 'approved')).toBe(true);
+    const fetched = await store.get(created.id);
+    expect(fetched!.status).toBe('approved');
+  });
+
+  it('updateStatus filters via statusFilter', async () => {
+    store = new SQLiteSkillStore();
+    const a = await store.add({ title: 's1', description: 'd' });
+    await store.add({ title: 's2', description: 'd' });
+    await store.updateStatus(a.id, 'approved');
+    const approvedHits = await store.search({ statusFilter: 'approved' });
+    expect(approvedHits).toHaveLength(1);
+    expect(approvedHits[0].id).toBe(a.id);
+  });
+
+  it('delete removes the skill', async () => {
+    store = new SQLiteSkillStore();
+    const created = await store.add({ title: 'tmp', description: 'tmp' });
+    expect(await store.delete(created.id)).toBe(true);
+    expect(await store.get(created.id)).toBeNull();
+  });
+
+  it('delete returns false for non-existent skill', async () => {
+    store = new SQLiteSkillStore();
+    expect(await store.delete('no-such')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

Adds local SQLite backends for source and skill storage, providing portable implementations that work without OceanBase.

## Related Issues

Closes #34
Depends on #30 (PR #31 must be merged first)

## Changes

- Add `storage/source_store/base.ts` — abstract SourceStoreBase interface
- Add `storage/source_store/sqlite.ts` — SQLiteSourceStore with CRUD + memory/skill linking
- Add `storage/skill_store/base.ts` — abstract SkillStoreBase interface
- Add `storage/skill_store/sqlite.ts` — SQLiteSkillStore with vector search and fulltext
- Extend `storage/base.ts` with optional VectorStore DDL methods (createCol, listCols, deleteCol, colInfo, reset)
- Add `tests/parity/source-skill-store.test.ts` (18 tests)

## Test Plan

- [x] `npx vitest run tests/parity/source-skill-store.test.ts` (18 tests passed)
- [x] `npx tsc --noEmit` (type check passed)

## Notes

This is a stacked PR depending on #31 (PR-1: config schema parity). The diff includes PR-1 commits. Please merge #31 first, then this PR's diff will reduce to only the storage changes.

## Checklist

- [x] Issue acceptance criteria met
- [x] Base interfaces + SQLite implementations included
- [x] OceanBase production backend remains out of scope
- [x] No unrelated files included